### PR TITLE
Add kwargs cache.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,20 @@ The long version: **Archivist** is designed to efficiently manage and process co
 To retrieve a transcript from a video, run the following command:
 
 ```bash
-get 'https://www.youtube.com/...' [output-dir]
+get 'https://www.youtube.com/...' -o output/path language=Japanese tags=learning,health,...
 ```
 
 - The transcript is saved as a JSON file, named after the video title.
 - If `output-dir` is omitted, the file is saved in the default directory.
+- Once typed kwargs, it caches and you don't need to type again.
+
+Next time run
+
+```bash
+get 'https://www.youtube.com/...'
+```
+
+It uses the last kwargs you use.
 
 ## Running Pipelines on Documents
 
@@ -79,7 +88,7 @@ This equals to `manage.py runserver` in django.
 
 [] Support Cookie for websites protected by login.
 
-[] Add kwargs pre-check and memo for easier use.
+[x] Add cache kwargs so no need to type every time.
 
 [x] Develope `mpipe`: A tool for tagging, rewriting, summarizing, and modifying stored files.
 

--- a/src/pipelines/transcript.py
+++ b/src/pipelines/transcript.py
@@ -103,7 +103,7 @@ def get_video_transcript(inputs: dict, **kwargs) -> dict:
     output_dir = os.path.abspath(
         os.path.expanduser(inputs.get("output_dir", config.archivist_results_path))
     )
-    
+
     video_path = download_video(url, output_dir)
     audio_path = extract_audio(video_path)
     transcript_text = transcript(audio_path)

--- a/src/server/views.py
+++ b/src/server/views.py
@@ -7,7 +7,12 @@ def post_list(request):
     return render(
         request,
         "post_list.html",
-        {"posts": posts, "tags": tags, "authors": authors, "page_title": " | All Posts"},
+        {
+            "posts": posts,
+            "tags": tags,
+            "authors": authors,
+            "page_title": " | All Posts",
+        },
     )
 
 
@@ -17,8 +22,14 @@ def post_list_tag(request, tag):
     return render(
         request,
         "post_list.html",
-        {"posts": posts, "tags": tags, "authors": authors, "page_title": f" | tag={tag}"},
+        {
+            "posts": posts,
+            "tags": tags,
+            "authors": authors,
+            "page_title": f" | tag={tag}",
+        },
     )
+
 
 def post_list_author(request, author):
     posts, tags, authors = get_all_posts()
@@ -26,7 +37,12 @@ def post_list_author(request, author):
     return render(
         request,
         "post_list.html",
-        {"posts": posts, "tags": tags, "authors": authors, "page_title": f" | author={author}"},
+        {
+            "posts": posts,
+            "tags": tags,
+            "authors": authors,
+            "page_title": f" | author={author}",
+        },
     )
 
 

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -1,7 +1,9 @@
 from .config import get_config
+from .cache import get_cache
 from .utils import std_out_err_redirect_tqdm
 
 __all__ = [
     "get_config",
+    "get_cache",
     "std_out_err_redirect_tqdm",
 ]

--- a/src/utils/cache.py
+++ b/src/utils/cache.py
@@ -1,0 +1,42 @@
+import os
+import json
+
+from .config import get_config
+
+config = get_config()
+
+
+class Cache:
+
+    def __init__(self, path=None):
+        if path:
+            self.cache_path = path
+        else:
+            self.cache_path = os.path.join(config.archivist_results_path, ".archivist")
+        self.cache = self._load()
+
+    def _load(self):
+        if not os.path.exists(self.cache_path):
+            return {}
+        with open(self.cache_path, "r") as f:
+            return json.load(f)
+
+    def _save(self, data):
+        with open(self.cache_path, "w") as f:
+            json.dump(data, f, indent=2, ensure_ascii=False, sort_keys=True)
+
+    def write(self, key, value):
+        self.cache[key] = value
+        self._save(self.cache)
+
+    def read(self, key):
+        return self.cache.get(key, None)
+
+    def delete(self, key):
+        if key in self.cache:
+            del self.cache[key]
+            self._save(self.cache)
+
+
+def get_cache(path=None) -> Cache:
+    return Cache(path)


### PR DESCRIPTION
Add kwargs cache. Omitting kwargs will use the arguments used last time.

Implemented by adding a cache file in the results path.